### PR TITLE
Fixed script aborting on non-existant traffic values

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -127,7 +127,7 @@ $.each(nodes, function(i, node){
 		enums.gateways[row.gateway] = true;
 		
 		if(row.isOnline) {
-			if (stats.uptime > 0) {
+			if (stats.uptime > 0 && typeof stats.traffic != 'undefined') {
 				row.traFwd        = stats.traffic.forward.bytes;
 				row.traRx         = stats.traffic.rx.bytes;
 				row.traTx         = stats.traffic.tx.bytes;


### PR DESCRIPTION
We at Aachen filter the traffic values from our nodes.json. Because the nodelist does not expect that, the nodelist only showed a blank screen until this patch was added.

Due to existence checks already existing for pretty much every other value, I added a small patch to check for the existence of traffic values as well. Maybe other communities also strike this value from their nodes.json and profit from an upstream change as well.

(BTW: Adding an explicit test for existance of the stats.uptime value was considered but unneccessary because `undefined > 0` evaluates to false anyway :smile: )
