### PR TITLE
Fixes eslint error

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -281,11 +281,12 @@ cols.forEach(function(el) {
 	el.hidden = nodelistconfig.showCols.indexOf(el.field) < 0;
 });
 
+var srcHtml;
 if(typeof nodelistconfig.downstreamSource == 'undefined') {
-	var srcHtml = '<a href="https://github.com/freifunkMUC/nodelist">Github</a> and is being developed by <a href="http://ffmuc.net">Freifunk München</a>.';
+	srcHtml = '<a href="https://github.com/freifunkMUC/nodelist">Github</a> and is being developed by <a href="http://ffmuc.net">Freifunk München</a>.';
 }
 else {
-	var srcHtml = nodelistconfig.downstreamSource.link(nodelistconfig.downstreamSource)+'.<br>'+
+	srcHtml = nodelistconfig.downstreamSource.link(nodelistconfig.downstreamSource)+'.<br>'+
 	'<small>Upstream is provided by <a href="http://ffmuc.net">Freifunk München</a>, which source code can be found on <a href="https://github.com/freifunkMUC/nodelist">GitHub</a>.</small>';
 }
 


### PR DESCRIPTION
I got a linter error which caused the build to fail on current master.

```
Running "eslint:target" (eslint) task

/home/david/nodelist/app/scripts/main.js
  288:6  error  "srcHtml" is already defined  no-redeclare

✖ 1 problem (1 error, 0 warnings)

Warning: Task "eslint:target" failed. Use --force to continue.

Aborted due to warnings.
```

This seems to be related to eslint/eslint#4646 (unintuitive double declaration due to hoisting). Declaring the variable only once outside the if-block solves this.
