### PR TITLE
Fix comparison for 'undefined'

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -42,7 +42,7 @@ var rawGraph = $.ajax({
 var enums = {gateways: {}, versions: {}, models: {}, sites: {}};
 
 $.each(rawNodes, function(i, node){
-	if(typeof node.nodeinfo == undefined) {
+	if(typeof node.nodeinfo == 'undefined') {
 		//console.log('Useless node:', node);
 		return;
 	}


### PR DESCRIPTION
`typeof xyz == undefined` isn't a meaningful comparison. You probably meant `typeof xyz == 'undefined'`.